### PR TITLE
Caching for GET/HEAD requests, disabled for others

### DIFF
--- a/lib/Collection.js
+++ b/lib/Collection.js
@@ -25,10 +25,23 @@ class Collection {
 
 		this.map = {};
 		this.Class = Class;
+		this.lastModified = Date.now();
 
 		this.save = function (ids, cb) {
 			process.nextTick(cb);
 		};
+	}
+
+	isModifiedSince(date) {
+		if (!date) {
+			return true;
+		}
+
+		if (!(date instanceof Date)) {
+			date = new Date(date);
+		}
+
+		return this.lastModified > date.getTime();
 	}
 
 	loadMap(map) {
@@ -48,6 +61,8 @@ class Collection {
 		} else {
 			this.map[id] = new this.Class(id, info);
 		}
+
+		this.lastModified = Date.now();
 	}
 
 	toJSON() {
@@ -101,6 +116,8 @@ class Collection {
 				} else {
 					delete this.map[id];
 				}
+			} else {
+				this.lastModified = Date.now();
 			}
 
 			return cb && cb(error);
@@ -114,6 +131,8 @@ class Collection {
 		this.save(this.getIds(), (error) => {
 			if (error) {
 				this.map = previous;
+			} else {
+				this.lastModified = Date.now();
 			}
 
 			return cb && cb(error);
@@ -123,30 +142,42 @@ class Collection {
 	del(id, cb) {
 		const previous = this.get(id);
 
-		if (previous) {
-			delete this.map[id];
-
-			this.save([id], (error) => {
-				if (error) {
-					this.map[id] = previous;
-				}
-
-				return cb && cb(error);
-			});
-		} else {
+		if (!previous) {
 			if (cb) {
 				process.nextTick(cb);
 			}
+			return;
 		}
+
+		delete this.map[id];
+
+		this.save([id], (error) => {
+			if (error) {
+				this.map[id] = previous;
+			} else {
+				this.lastModified = Date.now();
+			}
+
+			return cb && cb(error);
+		});
 	}
 
 	delAll(cb) {
-		const previous = this.map;
 		const ids = this.getIds();
+		if (ids.length === 0) {
+			if (cb) {
+				process.nextTick(cb);
+			}
+			return;
+		}
+
+		const previous = this.map;
 		this.map = {};
 		this.save(ids, (error) => {
 			if (error) {
 				this.map = previous;
+			} else {
+				this.lastModified = Date.now();
 			}
 
 			return cb && cb(error);

--- a/lib/ResponseContext.js
+++ b/lib/ResponseContext.js
@@ -33,6 +33,20 @@ class ResponseContext {
 		this.status = 500; // Internal server error
 		this.headers = {};
 		this.body = undefined;
+
+		if (this.req && this.req.method !== 'GET' && this.req.method !== 'HEAD') {
+			this.headers['cache-control'] = 'max-age=0, no-cache, no-store, must-revalidate';
+			this.headers.expires = 'Thu, 01 Jan 1970 00:00:00 GMT';
+		}
+	}
+
+	isModified(collection/*, resourceId */) {
+		// TODO: in the future, check modification time per resource
+		if (!this.req || !this.req.headers) {
+			return true;
+		}
+
+		return collection.isModifiedSince(this.req.headers['if-modified-since']);
 	}
 
 	isJson() {

--- a/lib/operations/collection/get.js
+++ b/lib/operations/collection/get.js
@@ -47,5 +47,9 @@ module.exports = function (collection, context, cb) {
 		return cb(context.setStatus(415)); // Unsupported Media Type
 	}
 
+	if (!context.isModified(collection)) {
+		return cb(context.setStatus(304)); // Not Modified
+	}
+
 	cb(context.setStatus(200).setBody(createMap(map, context)));
 };

--- a/lib/operations/resource/get.js
+++ b/lib/operations/resource/get.js
@@ -21,5 +21,9 @@ module.exports = function (collection, context, cb) {
 		return cb(context.setStatus(415)); // Unsupported Media Type
 	}
 
+	if (!context.isModified(collection)) {
+		return cb(context.setStatus(304)); // Not Modified
+	}
+
 	return cb(context.setStatus(200).setBody(resource)); // OK
 };

--- a/test/cache.js
+++ b/test/cache.js
@@ -1,0 +1,135 @@
+'use strict';
+
+const test = require('tape');
+const createServer = require('./helpers/server');
+
+
+test('HTTP cache', function (t) {
+	const options = { rights: true };
+
+	let server, collection, http;
+
+	const heineken = {
+		name: 'Heineken',
+		rating: 1
+	};
+
+	t.test('Start REST server', function (t) {
+		createServer(t, options, function (_server, _collection, _http) {
+			server = _server;
+			collection = _collection;
+			http = _http;
+
+			collection.loadOne('Heineken', heineken);
+			heineken.id = 'Heineken';
+
+			t.end();
+		});
+	});
+
+	t.test('GET /rest/beer/Heineken (no cache)', function (t) {
+		http.overrideHeader('if-modified-since', 'Sun, 06 Nov 1994 08:49:37 GMT');
+
+		http.get(t, '/rest/beer/Heineken', function (data, res) {
+			http.overrideHeader('if-modified-since');
+
+			t.equal(res.statusCode, 200, 'HTTP status 200 (OK)');
+			t.equal(res.headers['content-type'], 'application/json', 'JSON response');
+			t.deepEqual(data, heineken, 'Heineken returned');
+			t.end();
+		});
+	});
+
+	t.test('GET /rest/beer (no cache)', function (t) {
+		http.overrideHeader('if-modified-since', 'Sun, 06 Nov 1994 08:49:37 GMT');
+
+		http.get(t, '/rest/beer', function (data, res) {
+			http.overrideHeader('if-modified-since');
+
+			t.equal(res.statusCode, 200, 'HTTP status 200 (OK)');
+			t.equal(res.headers['content-type'], 'application/json', 'JSON response');
+			t.deepEqual(data, { Heineken: heineken }, 'Heineken returned');
+			t.end();
+		});
+	});
+
+	t.test('GET /rest/beer/Heineken (cache)', function (t) {
+		http.overrideHeader('if-modified-since', 'Wed, 06 Nov 2080 08:49:37 GMT');
+
+		http.get(t, '/rest/beer/Heineken', function (data, res) {
+			http.overrideHeader('if-modified-since');
+
+			t.equal(res.statusCode, 304, 'HTTP status 304 (Not Modified)');
+			t.equal(data, '', 'No response body');
+			t.end();
+		});
+	});
+
+	t.test('GET /rest/beer (cache)', function (t) {
+		http.overrideHeader('if-modified-since', 'Wed, 06 Nov 2080 08:49:37 GMT');
+
+		http.get(t, '/rest/beer', function (data, res) {
+			http.overrideHeader('if-modified-since');
+
+			t.equal(res.statusCode, 304, 'HTTP status 304 (Not Modified)');
+			t.equal(data, '', 'No response body');
+			t.end();
+		});
+	});
+
+	t.test('HEAD /rest/beer/Heineken (no cache)', function (t) {
+		http.overrideHeader('if-modified-since', 'Sun, 06 Nov 1994 08:49:37 GMT');
+
+		http.head(t, '/rest/beer/Heineken', function (data, res) {
+			http.overrideHeader('if-modified-since');
+
+			t.equal(res.statusCode, 200, 'HTTP status 200 (OK)');
+			t.equal(res.headers['content-type'], 'application/json', 'JSON response');
+			t.equal(data, '', 'No response body');
+			t.end();
+		});
+	});
+
+	t.test('HEAD /rest/beer/Heineken (cache)', function (t) {
+		http.overrideHeader('if-modified-since', 'Wed, 06 Nov 2080 08:49:37 GMT');
+
+		http.head(t, '/rest/beer/Heineken', function (data, res) {
+			http.overrideHeader('if-modified-since');
+
+			t.equal(res.statusCode, 304, 'HTTP status 304 (Not Modified)');
+			t.equal(data, '', 'No response body');
+			t.end();
+		});
+	});
+
+	t.test('DELETE /rest/beer/Heineken (disabled cache)', function (t) {
+		http.overrideHeader('if-modified-since', 'Wed, 06 Nov 2080 08:49:37 GMT');
+
+		http.delete(t, '/rest/beer/Heineken', function (data, res) {
+			http.overrideHeader('if-modified-since');
+
+			t.equal(res.statusCode, 204, 'HTTP status 204 (No content)');
+			t.ok(res.headers['cache-control'], 'Cache-Control header is set');
+			t.ok(res.headers.expires, 'Expires header is set');
+
+			if (res.headers['cache-control']) {
+				t.notEqual(res.headers['cache-control'].indexOf('no-cache'), -1, 'Cache-Control contains "no-cache"');
+				t.notEqual(res.headers['cache-control'].indexOf('no-store'), -1, 'Cache-Control contains "no-store"');
+			}
+
+			if (res.headers.expires) {
+				t.ok(new Date(res.headers.expires) < new Date(), 'Expires header is in the past');
+			}
+
+			t.end();
+		});
+	});
+
+
+
+	t.test('Close REST server', function (t) {
+		server.close(function () {
+			t.end();
+		});
+	});
+});

--- a/test/core-apis.js
+++ b/test/core-apis.js
@@ -51,10 +51,15 @@ test('Core APIs', function (t) {
 
 		col.request(true).post({ foo: 'bar' }, null, function (context) {
 			t.equal(context.status, 201, 'Created');
+			t.ok(context.isModified(), 'Response without req/res is always considered modified');
 
 			col.request(false).get('foo', null, null, function (context) {
 				t.equal(context.status, 404, 'Not Found');
-				t.end();
+
+				col.request(true).get('foo', 'jpeg', null, function (context) {
+					t.equal(context.status, 415, 'Unsupported Media Type (special extensions require req/res)');
+					t.end();
+				});
 			});
 		});
 	});
@@ -72,7 +77,14 @@ test('Core APIs', function (t) {
 
 		col.del('FooBar', function (error) {
 			t.ifError(error, 'Deleting non-existing is not an error');
+		});
+
+		col.delAll(function () {
 			t.end();
+		});
+
+		col.persist(function () {
+			t.fail('Persist should not be called');
 		});
 	});
 

--- a/test/helpers/HttpClient.js
+++ b/test/helpers/HttpClient.js
@@ -74,9 +74,9 @@ class HttpClient {
 		const url = parseUrl(this.baseUrl);
 		url.method = method;
 		url.path = path;
+		url.headers = {};
 
 		if (method === 'POST' || method === 'PUT' || method === 'PATCH') {
-			url.headers = url.headers || {};
 			url.headers['content-type'] = 'application/json';
 		}
 


### PR DESCRIPTION
Caching is per-collection, not per-resource, as that would be quite invasive to the architecture of collections. I'll have to ponder the implementation for that, but I think this is a good start.