### PR TITLE
Collection and resource ID handling altered to be case-insensitive for issue #49.

### DIFF
--- a/lib/Collection.js
+++ b/lib/Collection.js
@@ -21,6 +21,11 @@ class Collection {
 			throw new TypeError('Provided class is not a function (constructor)');
 		}
 
+		// A Collection is case-insensitive by default.
+		// When a Collection is case-insensitive, all map keys are converted to lowercase before use.
+		// If being used with a case-sensitive app or router, caseSensitive will be set to true by setupRoutes.
+		this.caseSensitive = false;
+
 		this.map = {};
 		this.Class = Class;
 		this.lastModified = Date.now();
@@ -76,10 +81,16 @@ class Collection {
 	}
 
 	has(id) {
+		if (!this.caseSensitive) {
+			id = id.toLowerCase();
+		}
 		return this.map.hasOwnProperty(id);
 	}
 
 	get(id) {
+		if (!this.caseSensitive) {
+			id = id.toLowerCase();
+		}
 		return this.map[id];
 	}
 
@@ -108,6 +119,9 @@ class Collection {
 	}
 
 	set(id, resource, cb) {
+		if (!this.caseSensitive) {
+			id = id.toLowerCase();
+		}
 		const previous = this.map[id];
 		this.map[id] = resource;
 
@@ -133,6 +147,16 @@ class Collection {
 
 	setAll(resources, cb) {
 		const previous = this.map;
+		if (!this.caseSensitive) {
+			// Lowercase all keys in the new resource set.
+			const lowercasedResources = {};
+			for (const key in resources) {
+				if (resources.hasOwnProperty(key)) {
+					lowercasedResources[key.toLowerCase()] = resources[key];
+				}
+			}
+			resources = lowercasedResources;
+		}
 		this.map = resources;
 
 		this.save(this.getIds(), (error) => {
@@ -149,6 +173,9 @@ class Collection {
 	}
 
 	del(id, cb) {
+		if (!this.caseSensitive) {
+			id = id.toLowerCase();
+		}
 		const previous = this.get(id);
 
 		if (!previous) {
@@ -350,6 +377,15 @@ class Collection {
 				}
 			};
 		}
+	}
+
+	getCaseSensitive() {
+		return this.caseSensitive;
+	}
+
+	setCaseSensitive(caseSensitive) {
+		// caseSensitive is retained as a Boolean value with value = truthiness of parameter
+		this.caseSensitive = caseSensitive;
 	}
 }
 

--- a/lib/setupRoutes.js
+++ b/lib/setupRoutes.js
@@ -81,9 +81,26 @@ function respond(context) {
 // route handlers
 
 module.exports = function setupRoutes(router, collection, path, rights) {
-	// Set up a regular expression for the given path and optionally allow extensions
+	// When router is a Router, router.caseSensitive will yield true or false,
+	// but when router is a base Express application, it will always yield undefined.
+	const routerCaseSensitive = router.caseSensitive;
 
-	const reCollection = new RegExp('^' + path + '(\\.[a-zA-Z]+)?/?$');
+	// When router is a Router, router.get('case sensitive routing') will yield a function,
+	// but when router is a base Express application, it will yield true, false or undefined.
+	const appCaseSensitiveRoutingSetting = router.get('case sensitive routing');
+	const appCaseSensitive = (typeof appCaseSensitiveRoutingSetting !== 'function' && appCaseSensitiveRoutingSetting);
+
+	// Set up a regular expression for the given path and optionally allow extensions.
+	// Also, set the collection's case sensitivity to match the app/router's case sensitivity,
+	// since this is one of the only places we currently have all this information together.
+	let reCollection;
+	if (appCaseSensitive || routerCaseSensitive) {
+		reCollection = new RegExp('^' + path + '(\\.[a-zA-Z]+)?/?$');
+		collection.setCaseSensitive(true);
+	} else {
+		reCollection = new RegExp('^' + path + '(\\.[a-z]+)?/?$', 'i');
+		collection.setCaseSensitive(false);
+	}
 
 	// GET all resources in the collection
 

--- a/test/cache.js
+++ b/test/cache.js
@@ -20,8 +20,8 @@ test('HTTP cache', function (t) {
 			collection = _collection;
 			http = _http;
 
-			collection.loadOne('Heineken', heineken);
-			heineken.id = 'Heineken';
+			collection.loadOne('heineken', heineken);
+			heineken.id = 'heineken';
 
 			t.end();
 		});
@@ -48,7 +48,7 @@ test('HTTP cache', function (t) {
 
 			t.equal(res.statusCode, 200, 'HTTP status 200 (OK)');
 			t.equal(res.headers['content-type'], 'application/json', 'JSON response');
-			t.deepEqual(data, { Heineken: heineken }, 'Heineken returned');
+			t.deepEqual(data, { heineken }, 'Heineken returned');
 			t.end();
 		});
 	});

--- a/test/case-sensitivity.js
+++ b/test/case-sensitivity.js
@@ -1,0 +1,450 @@
+'use strict';
+
+const test = require('tape');
+const createServer = require('./helpers/server');
+const rested = require('..');
+
+
+test('Case Sensitivity - Detection from Express/Router Settings', function (t) {
+	t.test('Collection created by case-sensitive instance using subrouter is also case-sensitive', function (t) {
+		const options = { caseSensitive: true };
+		createServer(t, options, function (_server, _collection) {
+			const server = _server;
+			const collection = _collection;
+			t.true(collection.getCaseSensitive(), 'Collection getCaseSensitive() is true');
+			server.close(function () {
+				t.end();
+			});
+		});
+	});
+
+	t.test('Collection created by case-insensitive instance using subrouter is also case-insensitive', function (t) {
+		const options = { caseSensitive: false };
+		createServer(t, options, function (_server, _collection) {
+			const server = _server;
+			const collection = _collection;
+			t.false(collection.getCaseSensitive(), 'Collection getCaseSensitive() is false');
+			server.close(function () {
+				t.end();
+			});
+		});
+	});
+
+	t.test('Collection created by case-sensitive instance using base app is also case-sensitive', function (t) {
+		const options = { caseSensitive: true, noSubRouter: true };
+		createServer(t, options, function (_server, _collection) {
+			const server = _server;
+			const collection = _collection;
+			t.true(collection.getCaseSensitive(), 'Collection getCaseSensitive() is true');
+			server.close(function () {
+				t.end();
+			});
+		});
+	});
+
+	t.test('Collection created by case-insensitive instance using base app is also case-insensitive', function (t) {
+		const options = { caseSensitive: false, noSubRouter: true };
+		createServer(t, options, function (_server, _collection) {
+			const server = _server;
+			const collection = _collection;
+			t.false(collection.getCaseSensitive(), 'Collection getCaseSensitive() is false');
+			server.close(function () {
+				t.end();
+			});
+		});
+	});
+});
+
+
+test('Case Sensitivity - Case Sensitive Mode', function (t) {
+	let server, collection, http;
+
+	const vb = {
+		name: 'VB',
+		rating: 1
+	};
+	const fourEcks = {
+		name: 'XXXX',
+		rating: 1
+	};
+
+	t.test('Setup case-sensitive REST server', function (t) {
+		const options = { rights: true, caseSensitive: true };
+		createServer(t, options, function (_server, _collection, _http) {
+			server = _server;
+			collection = _collection;
+			http = _http;
+			t.end();
+		});
+	});
+
+	t.test('Case-sensitive POST: Single resource, ID & key both match createId() verbatim', function (t) {
+		http.post(t, '/rest/beer', fourEcks, function (data, res) {
+			t.equal(res.statusCode, 201, 'HTTP status 201 (Created)');
+			fourEcks.id = fourEcks.name;
+			const expectedMap = { XXXX: fourEcks };
+			t.deepEqual(collection.getMap(), expectedMap, 'XXXX in collection with verbatim createId() as ID & key');
+			collection.delAll(function () {
+				t.end();
+			});
+		});
+	});
+
+	t.test('Case-insensitive POST: Differently-cased collection name yields 404 Not Found', function (t) {
+		http.post(t, '/rest/BeEr', fourEcks, function (data, res) {
+			t.equal(res.statusCode, 404, 'HTTP status 404 (Not Found)');
+			fourEcks.id = fourEcks.name;
+			t.deepEqual(collection.getMap(), {}, 'Collection still empty');
+			collection.delAll(function () {
+				t.end();
+			});
+		});
+	});
+
+	t.test('Case-sensitive POST: Identical resources with differently-cased IDs may coexist', function (t) {
+		const lowercaseVb = Object.assign({}, vb);
+		lowercaseVb.id = 'vb';
+
+		t.test('Setup: Insert lowercase-id VB beer in collection', function (t) {
+			collection.set(lowercaseVb.id, lowercaseVb, function () {
+				t.deepEqual(collection.getMap(), { vb: lowercaseVb }, 'Lowercase-id VB in collection');
+				t.end();
+			});
+		});
+
+		t.test('POST uppercase-id VB, coexists with lowercase-id VB', function (t) {
+			http.post(t, '/rest/beer', vb, function (data, res) {
+				t.equal(res.statusCode, 201, 'HTTP status 201 (Created)');
+				vb.id = 'VB';
+				const expectedMap = {
+					vb: lowercaseVb,
+					VB: vb
+				};
+				t.deepEqual(collection.getMap(), expectedMap, 'Uppercase-id VB and lowercase-id VB both in collection');
+				collection.delAll(function () {
+					t.end();
+				});
+			});
+		});
+	});
+
+	t.test('Case-sensitive GET & HEAD: Resource and path must have same case', function (t) {
+		t.test('Setup: Insert XXXX beer in collection', function (t) {
+			collection.set(fourEcks.id, fourEcks, function () {
+				t.end();
+			});
+		});
+
+		t.test('GET same-cased yields 200 OK, differently-cased yields 404 Not Found', function (t) {
+			t.plan(5);
+
+			http.get(t, '/rest/beer/XXXX', function (data, res) {
+				t.equal(res.statusCode, 200, 'HTTP status 200 (OK)');
+				t.deepEqual(data, fourEcks, 'XXXX returned');
+			});
+			http.get(t, '/rest/beer/xxxx', function (data, res) {
+				t.equal(res.statusCode, 404, 'HTTP status 404 (Not Found)');
+			});
+			http.get(t, '/rest/BEER/XXXX', function (data, res) {
+				t.equal(res.statusCode, 404, 'HTTP status 404 (Not Found)');
+			});
+			http.get(t, '/rest/BEER/xxxx', function (data, res) {
+				t.equal(res.statusCode, 404, 'HTTP status 404 (Not Found)');
+			});
+		});
+
+		t.test('HEAD same-cased yields 200 OK, differently-cased yields 404 Not Found', function (t) {
+			t.plan(6);
+
+			http.head(t, '/rest/beer/XXXX', function (data, res) {
+				t.equal(res.statusCode, 200, 'HTTP status 200 (OK)');
+				t.equal(res.headers['content-type'], 'application/json', 'JSON response');
+				t.equal(data, '', 'No response body');
+			});
+			http.head(t, '/rest/beer/xxxx', function (data, res) {
+				t.equal(res.statusCode, 404, 'HTTP status 404 (Not Found)');
+			});
+			http.head(t, '/rest/BEER/XXXX', function (data, res) {
+				t.equal(res.statusCode, 404, 'HTTP status 404 (Not Found)');
+			});
+			http.head(t, '/rest/BEER/xxxx', function (data, res) {
+				t.equal(res.statusCode, 404, 'HTTP status 404 (Not Found)');
+			});
+		});
+
+		t.test('Teardown: Clear collection', function (t) {
+			collection.delAll(function () {
+				t.end();
+			});
+		});
+	});
+
+	t.test('Case-sensitive collection PUT', function (t) {
+		t.test('Case-sensitive collection PUT: IDs & keys retain original case, existing IDs respected', function (t) {
+			// Let's re-set the beers for this test to make it clear what's happening to their IDs during PUT.
+			const vb = {
+				id: 'arbitraryvbkey',
+				name: 'VB',
+				rating: 1
+			};
+			const fourEcks = {
+				id: 'XXXX',
+				name: 'XXXX',
+				rating: 1
+			};
+			const boag = {
+				name: `James Boag's Draught`,
+				rating: 3
+			};
+			const cascade = {
+				name: 'Cascade Pale Ale',
+				rating: 5
+			};
+			const allBeers = {
+				vb,
+				fourEcks,
+				boag,
+				CASCADE: cascade
+			};
+
+			const expectedVb = Object.assign({}, vb);
+			expectedVb.id = 'vb'; // Inner ID present: Final ID will be will be assigned from key in request object
+			const expectedFourEcks = Object.assign({}, fourEcks);
+			expectedFourEcks.id = 'fourEcks'; // Inner ID present: Final ID will be will be assigned from key in request object
+			const expectedBoag = Object.assign({}, boag);
+			expectedBoag.id = 'boag'; // No inner ID present: Final ID will be assigned from key
+			const expectedCascade = Object.assign({}, cascade);
+			expectedCascade.id = 'CASCADE'; // No inner ID present: Final ID will be assigned from key
+
+			const expectedAllBeers = {
+				vb: expectedVb,
+				fourEcks: expectedFourEcks, // key case retained
+				boag: expectedBoag,
+				CASCADE: expectedCascade // key case retained
+			};
+
+			http.put(t, '/rest/beer', allBeers, function (data, res) {
+				t.equal(res.statusCode, 204, 'HTTP status 204 (No Content)');
+				t.deepEqual(collection.getMap(), expectedAllBeers, 'Replaced entire collection');
+				t.end();
+			});
+		});
+
+		t.test('Teardown: Clear collection', function (t) {
+			collection.delAll(function () {
+				t.end();
+			});
+		});
+	});
+
+	t.test('Teardown case-sensitive REST server', function (t) {
+		server.close(function () {
+			t.end();
+		});
+	});
+});
+
+
+test('Case Sensitivity - Case Insensitive Mode', function (t) {
+	let server, collection, http;
+
+	const vb = {
+		name: 'VB',
+		rating: 1
+	};
+	const fourEcks = {
+		name: 'XXXX',
+		rating: 1
+	};
+
+	t.test('Setup case-insensitive REST server', function (t) {
+		const options = { rights: true, caseSensitive: false };
+		createServer(t, options, function (_server, _collection, _http) {
+			server = _server;
+			collection = _collection;
+			http = _http;
+			t.end();
+		});
+	});
+
+	t.test('Case-insensitive POST: Single resource, key from createId() lowercased', function (t) {
+		http.post(t, '/rest/beer', fourEcks, function (data, res) {
+			t.equal(res.statusCode, 201, 'HTTP status 201 (Created)');
+			fourEcks.id = fourEcks.name;
+			const expectedMap = { xxxx: fourEcks };
+			t.deepEqual(collection.getMap(), expectedMap, 'XXXX in collection with ID = name and key lowercased');
+			collection.delAll(function () {
+				t.end();
+			});
+		});
+	});
+
+	t.test('Case-insensitive POST: Single resource created despite differently-cased collection name', function (t) {
+		http.post(t, '/rest/BeEr', fourEcks, function (data, res) {
+			t.equal(res.statusCode, 201, 'HTTP status 201 (Created)');
+			fourEcks.id = fourEcks.name;
+			const expectedMap = { xxxx: fourEcks };
+			t.deepEqual(collection.getMap(), expectedMap, 'XXXX in collection');
+			collection.delAll(function () {
+				t.end();
+			});
+		});
+	});
+
+	t.test('Case-insensitive POST: Identical resources with differently-cased IDs conflict', function (t) {
+		const lowercaseVb = Object.assign({}, vb);
+		lowercaseVb.id = 'vb';
+
+		t.test('Setup: Insert lowercase-id VB beer in collection', function (t) {
+			collection.set(lowercaseVb.id, lowercaseVb, function () {
+				t.deepEqual(collection.getMap(), { vb: lowercaseVb }, 'Lowercase-id VB in collection');
+				t.end();
+			});
+		});
+
+		t.test('POST uppercase-id VB conflicts with lowercase-id VB, emits error', function (t) {
+			let errors = 0;
+			rested.on('error', function (error) {
+				t.ok(error, 'Error emitted');
+				errors += 1;
+			});
+
+			http.post(t, '/rest/beer', vb, function (data, res) {
+				t.equal(res.statusCode, 500, 'HTTP status 500 (Internal Server Error)');
+				const expectedMap = {
+					vb: lowercaseVb
+				};
+				t.deepEqual(collection.getMap(), expectedMap, 'Only lowercase-id VB both in collection');
+				t.equal(errors, 1, 'One error was emitted');
+				rested.removeAllListeners();
+
+				collection.delAll(function () {
+					t.end();
+				});
+			});
+		});
+	});
+
+	t.test('Case-insensitive GET & HEAD: Resource and path may be any case', function (t) {
+		t.test('Setup: Insert XXXX beer in collection', function (t) {
+			collection.set(fourEcks.id, fourEcks, function () {
+				t.end();
+			});
+		});
+
+		t.test('GET any combination of resource & path case yields 200 OK', function (t) {
+			t.plan(8);
+			http.get(t, '/rest/beer/XxXX', function (data, res) {
+				t.equal(res.statusCode, 200, 'HTTP status 200 (OK)');
+				t.deepEqual(data, fourEcks, 'XXXX returned');
+			});
+			http.get(t, '/rest/beer/xxxx', function (data, res) {
+				t.equal(res.statusCode, 200, 'HTTP status 200 (OK)');
+				t.deepEqual(data, fourEcks, 'XXXX returned');
+			});
+			http.get(t, '/REST/BEER/XXXX', function (data, res) {
+				t.equal(res.statusCode, 200, 'HTTP status 200 (OK)');
+				t.deepEqual(data, fourEcks, 'XXXX returned');
+			});
+			http.get(t, '/rest/BEER/xxxx', function (data, res) {
+				t.equal(res.statusCode, 200, 'HTTP status 200 (OK)');
+				t.deepEqual(data, fourEcks, 'XXXX returned');
+			});
+		});
+
+		t.test('HEAD same-cased resource & path yields 200 OK', function (t) {
+			t.plan(12);
+
+			http.head(t, '/rest/beer/XXXX', function (data, res) {
+				t.equal(res.statusCode, 200, 'HTTP status 200 (OK)');
+				t.equal(res.headers['content-type'], 'application/json', 'JSON response');
+				t.equal(data, '', 'No response body');
+			});
+			http.head(t, '/rest/beer/xxxx', function (data, res) {
+				t.equal(res.statusCode, 200, 'HTTP status 200 (OK)');
+				t.equal(res.headers['content-type'], 'application/json', 'JSON response');
+				t.equal(data, '', 'No response body');
+			});
+			http.head(t, '/rest/BEER/XXXX', function (data, res) {
+				t.equal(res.statusCode, 200, 'HTTP status 200 (OK)');
+				t.equal(res.headers['content-type'], 'application/json', 'JSON response');
+				t.equal(data, '', 'No response body');
+			});
+			http.head(t, '/rest/BEER/xxxx', function (data, res) {
+				t.equal(res.statusCode, 200, 'HTTP status 200 (OK)');
+				t.equal(res.headers['content-type'], 'application/json', 'JSON response');
+				t.equal(data, '', 'No response body');
+			});
+		});
+
+		t.test('Teardown: Clear collection', function (t) {
+			collection.delAll(function () {
+				t.end();
+			});
+		});
+	});
+
+	t.test('Case-insensitive collection PUT', function (t) {
+		t.test('Case-insensitive collection PUT: Keys lowercased, existing IDs respected', function (t) {
+			// Let's re-set the beers for this test to make it clear what's happening to their IDs during PUT.
+			const vb = {
+				id: 'arbitraryvbkey',
+				name: 'VB',
+				rating: 1
+			};
+			const fourEcks = {
+				id: 'XXXX',
+				name: 'XXXX',
+				rating: 1
+			};
+			const boag = {
+				name: `James Boag's Draught`,
+				rating: 3
+			};
+			const cascade = {
+				name: 'Cascade Pale Ale',
+				rating: 5
+			};
+			const allBeers = {
+				vb,
+				fourEcks,
+				boag,
+				CASCADE: cascade
+			};
+
+			const expectedVb = Object.assign({}, vb); // key will be assigned from ID
+			expectedVb.id = 'vb'; // Inner ID present: Final ID will be will be assigned from key in request object
+			const expectedFourEcks = Object.assign({}, fourEcks);
+			expectedFourEcks.id = 'fourEcks'; // Inner ID present: Final ID will be will be assigned from key in request object
+			const expectedBoag = Object.assign({}, boag);
+			expectedBoag.id = 'boag'; // ID will be assigned from key
+			const expectedCascade = Object.assign({}, cascade);
+			expectedCascade.id = 'CASCADE'; // ID will be assigned from key (as passed in request)
+
+			const expectedAllBeers = {
+				vb: expectedVb,
+				fourecks: expectedFourEcks, // key lowercased
+				boag: expectedBoag,
+				cascade: expectedCascade // key lowercased
+			};
+
+			http.put(t, '/rest/beer', allBeers, function (data, res) {
+				t.equal(res.statusCode, 204, 'HTTP status 204 (No Content)');
+				t.deepEqual(collection.getMap(), expectedAllBeers, 'Replaced entire collection');
+				t.end();
+			});
+		});
+
+		t.test('Teardown: Clear collection', function (t) {
+			collection.delAll(function () {
+				t.end();
+			});
+		});
+	});
+
+	t.test('Teardown case-insensitive REST server', function (t) {
+		server.close(function () {
+			t.end();
+		});
+	});
+});

--- a/test/extensions.js
+++ b/test/extensions.js
@@ -43,7 +43,7 @@ test('Extensions', function (t) {
 		});
 
 		t.test('PUT /rest/beer/Heineken.txt', function (t) {
-			collection.loadOne('Heineken', heineken);
+			collection.loadOne('heineken', heineken);
 
 			http.put(t, '/rest/beer/Heineken.txt', { hello: 'world' }, function (data, res) {
 				t.equal(res.statusCode, 200, 'HTTP status 200 (OK)');
@@ -78,8 +78,8 @@ test('Extensions', function (t) {
 
 		t.test('GET /rest/beer/Heineken (with getJson method)', function (t) {
 			const body = { hello: 'world' };
-			collection.loadOne('Heineken', heineken);
-			const obj = collection.get('Heineken');
+			collection.loadOne('heineken', heineken);
+			const obj = collection.get('heineken');
 
 			obj.getJson = function (req, res) {
 				res.writeHead(200, { 'content-type': 'application/json' });
@@ -131,14 +131,14 @@ test('Extensions', function (t) {
 
 	t.test('Collection extensions', function (t) {
 		t.test('GET /rest/beer.txt', function (t) {
-			collection.loadOne('Heineken', heineken);
-			collection.loadOne('Suntory Premium', suntory);
-			collection.loadOne('Rochefort', rochefort);
+			collection.loadOne('heineken', heineken);
+			collection.loadOne('suntory premium', suntory);
+			collection.loadOne('rochefort', rochefort);
 
 			const expectedData = [
-				JSON.stringify(collection.get('Heineken')),
-				JSON.stringify(collection.get('Rochefort')),
-				JSON.stringify(collection.get('Suntory Premium'))
+				JSON.stringify(collection.get('heineken')),
+				JSON.stringify(collection.get('rochefort')),
+				JSON.stringify(collection.get('suntory premium'))
 			].join('\n');
 
 			http.get(t, '/rest/beer.txt', function (data, res) {
@@ -178,7 +178,7 @@ test('Extensions', function (t) {
 	});
 
 	t.test('Error handling', function (t) {
-		collection.loadOne('Heineken', heineken);
+		collection.loadOne('heineken', heineken);
 
 		let errors = 0;
 

--- a/test/helpers/server.js
+++ b/test/helpers/server.js
@@ -9,7 +9,9 @@ const Beer = require('./Beer');
 module.exports = function (t, options, cb) {
 	const path = '/beer';
 	const app = express();
-	const router = new express.Router();
+	// Use both app and router in case-insensitive mode by default (coalesce to false)
+	app.set('case sensitive routing', options.caseSensitive || false);
+	const router = new express.Router({ caseSensitive: options.caseSensitive || false });
 	const rested = require('../..');
 
 	if (options.autoParse) {

--- a/test/helpers/server.js
+++ b/test/helpers/server.js
@@ -18,9 +18,16 @@ module.exports = function (t, options, cb) {
 		app.use(bodyParser.json());
 	}
 
-	app.use('/rest', router);
+	// By defult, use a subrouter under /rest
+	// Option noSubRouter instead uses a base Express app under /
+	let route;
+	if (options.noSubRouter) {
+		route = rested.route(app);
+	} else {
+		app.use('/rest', router);
+		route = rested.route(router);
+	}
 
-	const route = rested.route(router);
 	const collection = rested.createCollection(Beer);
 
 	route(collection, path, options);

--- a/test/indexes.js
+++ b/test/indexes.js
@@ -31,10 +31,10 @@ test('Indexes', function (t) {
 	};
 
 	const all = {
-		Heineken: heineken,
-		SuntoryPremium: suntory,
-		Rochefort: rochefort,
-		DeMolen: demolen
+		heineken,
+		suntory,
+		rochefort,
+		demolen
 	};
 
 

--- a/test/methods.js
+++ b/test/methods.js
@@ -7,7 +7,7 @@ const rested = require('..');
 
 
 test('Methods', function (t) {
-	const options = { rights: true };
+	const options = { rights: true, caseSensitive: false };
 
 	let server, collection, http, Beer;
 
@@ -40,7 +40,7 @@ test('Methods', function (t) {
 	};
 
 	const demolen = {
-		id: 'demolen',
+		id: 'DeMolen',
 		name: 'De Molen - Hop en Liefde',
 		rating: 5
 	};
@@ -148,11 +148,11 @@ test('Methods', function (t) {
 	t.test('POST /rest/beer?foo=bar (Heineken)', function (t) {
 		http.post(t, '/rest/beer?foo=bar', heineken, function (data, res) {
 			t.equal(res.statusCode, 201, 'HTTP status 201 (Created)');
-			t.equal(res.headers.location, '/rest/beer/heineken', 'Location header is correct');
+			t.equal(res.headers.location, '/rest/beer/Heineken', 'Location header is correct');
 
-			heineken.id = 'heineken';
+			heineken.id = 'Heineken';
 
-			t.deepEqual(heineken, collection.get('heineken'), 'Heineken in collection');
+			t.deepEqual(heineken, collection.get('Heineken'), 'Heineken in collection');
 
 			// now retrieve it
 			http.get(t, res.headers.location, function (data, res) {
@@ -200,68 +200,7 @@ test('Methods', function (t) {
 			t.equal(res.statusCode, 200, 'HTTP status 200 (OK)');
 			t.equal(res.headers['content-type'], 'application/json', 'JSON response');
 			t.deepEqual(data, heineken, 'Heineken returned');
-			t.deepEqual(data, collection.get('heineken'), 'Heineken in collection');
-			t.end();
-		});
-	});
-
-	t.test('GET /rest/beer/HEINEKEN returns resource despite different capitalisation for resource name', function (t) {
-		http.get(t, '/rest/beer/HEINEKEN', function (data, res) {
-			t.equal(res.statusCode, 200, 'HTTP status 200 (OK)');
-			t.equal(res.headers['content-type'], 'application/json', 'JSON response');
-			t.deepEqual(data, heineken, 'Heineken returned');
-			t.deepEqual(data, collection.get('heineken'), 'Heineken in collection');
-			t.end();
-		});
-	});
-
-	t.test('GET /rest/BEER/Heineken returns resource despite different capitalisation for collection name', function (t) {
-		http.get(t, '/rest/BEER/Heineken', function (data, res) {
-			t.equal(res.statusCode, 200, 'HTTP status 200 (OK)');
-			t.equal(res.headers['content-type'], 'application/json', 'JSON response');
-			t.deepEqual(data, heineken, 'Heineken returned');
-			t.deepEqual(data, collection.get('heineken'), 'Heineken in collection');
-			t.end();
-		});
-	});
-
-	t.test('POST /rest/beer (heineken), different capitalisation for resource name', function (t) {
-		const lowerHeineken = {
-			name: 'heineken',
-			rating: 3
-		};
-
-		let errors = 0;
-
-		rested.on('error', function (error) {
-			t.ok(error, 'Error emitted');
-			errors += 1;
-		});
-
-		http.post(t, '/rest/beer', lowerHeineken, function (data, res) {
-			t.equal(res.statusCode, 500, 'HTTP status 500 (Internal Server Error)');
-			t.equal(errors, 1, 'One error emitted');
-
-			rested.removeAllListeners();
-
-			t.end();
-		});
-	});
-
-	t.test('POST /rest/BEER (Heineken), different capitalisation for collection name', function (t) {
-		let errors = 0;
-
-		rested.on('error', function (error) {
-			t.ok(error, 'Error emitted');
-			errors += 1;
-		});
-
-		http.post(t, '/rest/BEER', heineken, function (data, res) {
-			t.equal(res.statusCode, 500, 'HTTP status 500 (Internal Server Error)');
-			t.equal(errors, 1, 'One error emitted');
-
-			rested.removeAllListeners();
-
+			t.deepEqual(data, collection.get('Heineken'), 'Heineken in collection');
 			t.end();
 		});
 	});
@@ -277,24 +216,6 @@ test('Methods', function (t) {
 
 	t.test('HEAD /rest/beer/Heineken', function (t) {
 		http.head(t, '/rest/beer/Heineken', function (data, res) {
-			t.equal(res.statusCode, 200, 'HTTP status 200 (OK)');
-			t.equal(res.headers['content-type'], 'application/json', 'JSON response');
-			t.equal(data, '', 'No response body');
-			t.end();
-		});
-	});
-
-	t.test('HEAD /rest/beer/HEINEKEN, different capitalisation for resource name', function (t) {
-		http.head(t, '/rest/beer/HEINEKEN', function (data, res) {
-			t.equal(res.statusCode, 200, 'HTTP status 200 (OK)');
-			t.equal(res.headers['content-type'], 'application/json', 'JSON response');
-			t.equal(data, '', 'No response body');
-			t.end();
-		});
-	});
-
-	t.test('HEAD /rest/BEER/Heineken, different capitalisation for collection name', function (t) {
-		http.head(t, '/rest/BEER/Heineken', function (data, res) {
 			t.equal(res.statusCode, 200, 'HTTP status 200 (OK)');
 			t.equal(res.headers['content-type'], 'application/json', 'JSON response');
 			t.equal(data, '', 'No response body');
@@ -389,30 +310,6 @@ test('Methods', function (t) {
 		});
 	});
 
-	t.test('PUT /rest/beer/SUNTORYPREMIUM (update), different capitalisation for resource name', function (t) {
-		suntory.rating = 4.6;
-
-		http.put(t, '/rest/beer/SUNTORYPREMIUM', suntory, function (data, res) {
-			t.equal(res.statusCode, 204, 'HTTP status 204 (No Content)');
-			t.ok(res.headers.location, 'Location header returned');
-			t.equal(res.headers.location, '/rest/beer/' + suntory.id, 'Location header points to a beer');
-			t.deepEqual(suntory, collection.get(suntory.id), 'Suntory in collection');
-			t.end();
-		});
-	});
-
-	t.test('PUT /rest/BEER/SuntoryPremium (update), different capitalisation for collection name', function (t) {
-		suntory.rating = 4.7;
-
-		http.put(t, '/rest/BEER/SuntoryPremium', suntory, function (data, res) {
-			t.equal(res.statusCode, 204, 'HTTP status 204 (No Content)');
-			t.ok(res.headers.location, 'Location header returned');
-			t.equal(res.headers.location, '/rest/beer/' + suntory.id, 'Location header points to a beer');
-			t.deepEqual(suntory, collection.get(suntory.id), 'Suntory in collection');
-			t.end();
-		});
-	});
-
 	t.test('PATCH /rest/beer/Heineken (no data)', function (t) {
 		http.patch(t, '/rest/beer/Heineken', '', function (data, res) {
 			t.equal(res.statusCode, 400, 'HTTP status 400 (Bad Request)');
@@ -462,33 +359,7 @@ test('Methods', function (t) {
 		http.patch(t, '/rest/beer/Heineken', patch, function (data, res) {
 			t.equal(res.statusCode, 204, 'HTTP status 204 (No Content)');
 			heineken.rating = patch.rating;
-			t.deepEqual(collection.get('heineken'), heineken, 'Heineken with new ranking in collection');
-			t.end();
-		});
-	});
-
-	t.test('PATCH /rest/beer/HEINEKEN, different capitalisation for resource name', function (t) {
-		const patch = {
-			rating: 2.5
-		};
-
-		http.patch(t, '/rest/beer/HEINEKEN', patch, function (data, res) {
-			t.equal(res.statusCode, 204, 'HTTP status 204 (No Content)');
-			heineken.rating = patch.rating;
-			t.deepEqual(collection.get('heineken'), heineken, 'Heineken with new ranking in collection');
-			t.end();
-		});
-	});
-
-	t.test('PATCH /rest/BEER/Heineken, different capitalisation for collection name', function (t) {
-		const patch = {
-			rating: 2.6
-		};
-
-		http.patch(t, '/rest/beer/Heineken', patch, function (data, res) {
-			t.equal(res.statusCode, 204, 'HTTP status 204 (No Content)');
-			heineken.rating = patch.rating;
-			t.deepEqual(collection.get('heineken'), heineken, 'Heineken with new ranking in collection');
+			t.deepEqual(collection.get('Heineken'), heineken, 'Heineken with new ranking in collection');
 			t.end();
 		});
 	});
@@ -501,24 +372,8 @@ test('Methods', function (t) {
 		});
 	});
 
-	t.test('GET /rest/BEER returns beer collection despite different capitalisation for collection name', function (t) {
-		http.get(t, '/rest/BEER', function (data, res) {
-			t.equal(res.statusCode, 200, 'HTTP status 200 (OK)');
-			t.deepEqual(data, allButDeMolen, 'All beers but De Molen returned');
-			t.end();
-		});
-	});
-
 	t.test('GET /rest/beer/ (trailing slash)', function (t) {
 		http.get(t, '/rest/beer/', function (data, res) {
-			t.equal(res.statusCode, 200, 'HTTP status 200 (OK)');
-			t.deepEqual(data, allButDeMolen, 'All beers but De Molen returned');
-			t.end();
-		});
-	});
-
-	t.test('GET /rest/BEER/ (trailing slash), different capitalisation for collection name', function (t) {
-		http.get(t, '/rest/BEER/', function (data, res) {
 			t.equal(res.statusCode, 200, 'HTTP status 200 (OK)');
 			t.deepEqual(data, allButDeMolen, 'All beers but De Molen returned');
 			t.end();
@@ -562,7 +417,7 @@ test('Methods', function (t) {
 
 	t.test('GET /rest/beer.txt?name=en (search)', function (t) {
 		http.get(t, '/rest/beer.txt?name=en', function (data, res) {
-			heineken.id = 'heineken';
+			heineken.id = 'Heineken';
 			const expectedData = [demolen, heineken];
 
 			t.equal(res.statusCode, 200, 'HTTP status 200 (OK)');
@@ -646,7 +501,7 @@ test('Methods', function (t) {
 
 		http.delete(t, '/rest/beer/Heineken', function (data, res) {
 			t.equal(res.statusCode, 204, 'HTTP status 204 (No Content)');
-			t.deepEqual([demolen.id, rochefort.id], collection.getIds().sort(), 'Heineken is out');
+			t.deepEqual(collection.getList().sort(), [rochefort, demolen], 'Heineken is out');
 			t.equals(deletedName, 'Heineken', 'Heineken deleted() called');
 			t.end();
 		});

--- a/test/methods.js
+++ b/test/methods.js
@@ -40,33 +40,33 @@ test('Methods', function (t) {
 	};
 
 	const demolen = {
-		id: 'DeMolen',
+		id: 'demolen',
 		name: 'De Molen - Hop en Liefde',
 		rating: 5
 	};
 
 	const all = {
-		Heineken: heineken,
-		SuntoryPremium: suntory,
-		Rochefort: rochefort,
-		DeMolen: demolen
+		heineken,
+		suntorypremium: suntory,
+		rochefort,
+		demolen
 	};
 
 	const enMatchers = {
-		DeMolen: demolen,
-		Heineken: heineken
+		demolen,
+		heineken
 	};
 
 	const allButSuntory = {
-		Heineken: heineken,
-		Rochefort: rochefort,
-		DeMolen: demolen
+		heineken,
+		rochefort,
+		demolen
 	};
 
 	const allButDeMolen = {
-		Heineken: heineken,
-		SuntoryPremium: suntory,
-		Rochefort: rochefort
+		heineken,
+		suntorypremium: suntory,
+		rochefort
 	};
 
 	t.test('POST /rest/beer (no data)', function (t) {
@@ -148,11 +148,11 @@ test('Methods', function (t) {
 	t.test('POST /rest/beer?foo=bar (Heineken)', function (t) {
 		http.post(t, '/rest/beer?foo=bar', heineken, function (data, res) {
 			t.equal(res.statusCode, 201, 'HTTP status 201 (Created)');
-			t.equal(res.headers.location, '/rest/beer/Heineken', 'Location header is correct');
+			t.equal(res.headers.location, '/rest/beer/heineken', 'Location header is correct');
 
-			heineken.id = 'Heineken';
+			heineken.id = 'heineken';
 
-			t.deepEqual(heineken, collection.get('Heineken'), 'Heineken in collection');
+			t.deepEqual(heineken, collection.get('heineken'), 'Heineken in collection');
 
 			// now retrieve it
 			http.get(t, res.headers.location, function (data, res) {
@@ -190,7 +190,7 @@ test('Methods', function (t) {
 			rochefort.id = id;
 
 			t.equal(res.headers.location, '/rest/beer/' + id, 'Location header points to a beer');
-			t.deepEqual(rochefort, collection.get(id), 'Rochefort in collection');
+			t.deepEqual(collection.get(id), rochefort, 'Rochefort in collection');
 			t.end();
 		});
 	});
@@ -200,7 +200,68 @@ test('Methods', function (t) {
 			t.equal(res.statusCode, 200, 'HTTP status 200 (OK)');
 			t.equal(res.headers['content-type'], 'application/json', 'JSON response');
 			t.deepEqual(data, heineken, 'Heineken returned');
-			t.deepEqual(data, collection.get('Heineken'), 'Heineken in collection');
+			t.deepEqual(data, collection.get('heineken'), 'Heineken in collection');
+			t.end();
+		});
+	});
+
+	t.test('GET /rest/beer/HEINEKEN returns resource despite different capitalisation for resource name', function (t) {
+		http.get(t, '/rest/beer/HEINEKEN', function (data, res) {
+			t.equal(res.statusCode, 200, 'HTTP status 200 (OK)');
+			t.equal(res.headers['content-type'], 'application/json', 'JSON response');
+			t.deepEqual(data, heineken, 'Heineken returned');
+			t.deepEqual(data, collection.get('heineken'), 'Heineken in collection');
+			t.end();
+		});
+	});
+
+	t.test('GET /rest/BEER/Heineken returns resource despite different capitalisation for collection name', function (t) {
+		http.get(t, '/rest/BEER/Heineken', function (data, res) {
+			t.equal(res.statusCode, 200, 'HTTP status 200 (OK)');
+			t.equal(res.headers['content-type'], 'application/json', 'JSON response');
+			t.deepEqual(data, heineken, 'Heineken returned');
+			t.deepEqual(data, collection.get('heineken'), 'Heineken in collection');
+			t.end();
+		});
+	});
+
+	t.test('POST /rest/beer (heineken), different capitalisation for resource name', function (t) {
+		const lowerHeineken = {
+			name: 'heineken',
+			rating: 3
+		};
+
+		let errors = 0;
+
+		rested.on('error', function (error) {
+			t.ok(error, 'Error emitted');
+			errors += 1;
+		});
+
+		http.post(t, '/rest/beer', lowerHeineken, function (data, res) {
+			t.equal(res.statusCode, 500, 'HTTP status 500 (Internal Server Error)');
+			t.equal(errors, 1, 'One error emitted');
+
+			rested.removeAllListeners();
+
+			t.end();
+		});
+	});
+
+	t.test('POST /rest/BEER (Heineken), different capitalisation for collection name', function (t) {
+		let errors = 0;
+
+		rested.on('error', function (error) {
+			t.ok(error, 'Error emitted');
+			errors += 1;
+		});
+
+		http.post(t, '/rest/BEER', heineken, function (data, res) {
+			t.equal(res.statusCode, 500, 'HTTP status 500 (Internal Server Error)');
+			t.equal(errors, 1, 'One error emitted');
+
+			rested.removeAllListeners();
+
 			t.end();
 		});
 	});
@@ -216,6 +277,24 @@ test('Methods', function (t) {
 
 	t.test('HEAD /rest/beer/Heineken', function (t) {
 		http.head(t, '/rest/beer/Heineken', function (data, res) {
+			t.equal(res.statusCode, 200, 'HTTP status 200 (OK)');
+			t.equal(res.headers['content-type'], 'application/json', 'JSON response');
+			t.equal(data, '', 'No response body');
+			t.end();
+		});
+	});
+
+	t.test('HEAD /rest/beer/HEINEKEN, different capitalisation for resource name', function (t) {
+		http.head(t, '/rest/beer/HEINEKEN', function (data, res) {
+			t.equal(res.statusCode, 200, 'HTTP status 200 (OK)');
+			t.equal(res.headers['content-type'], 'application/json', 'JSON response');
+			t.equal(data, '', 'No response body');
+			t.end();
+		});
+	});
+
+	t.test('HEAD /rest/BEER/Heineken, different capitalisation for collection name', function (t) {
+		http.head(t, '/rest/BEER/Heineken', function (data, res) {
 			t.equal(res.statusCode, 200, 'HTTP status 200 (OK)');
 			t.equal(res.headers['content-type'], 'application/json', 'JSON response');
 			t.equal(data, '', 'No response body');
@@ -310,6 +389,30 @@ test('Methods', function (t) {
 		});
 	});
 
+	t.test('PUT /rest/beer/SUNTORYPREMIUM (update), different capitalisation for resource name', function (t) {
+		suntory.rating = 4.6;
+
+		http.put(t, '/rest/beer/SUNTORYPREMIUM', suntory, function (data, res) {
+			t.equal(res.statusCode, 204, 'HTTP status 204 (No Content)');
+			t.ok(res.headers.location, 'Location header returned');
+			t.equal(res.headers.location, '/rest/beer/' + suntory.id, 'Location header points to a beer');
+			t.deepEqual(suntory, collection.get(suntory.id), 'Suntory in collection');
+			t.end();
+		});
+	});
+
+	t.test('PUT /rest/BEER/SuntoryPremium (update), different capitalisation for collection name', function (t) {
+		suntory.rating = 4.7;
+
+		http.put(t, '/rest/BEER/SuntoryPremium', suntory, function (data, res) {
+			t.equal(res.statusCode, 204, 'HTTP status 204 (No Content)');
+			t.ok(res.headers.location, 'Location header returned');
+			t.equal(res.headers.location, '/rest/beer/' + suntory.id, 'Location header points to a beer');
+			t.deepEqual(suntory, collection.get(suntory.id), 'Suntory in collection');
+			t.end();
+		});
+	});
+
 	t.test('PATCH /rest/beer/Heineken (no data)', function (t) {
 		http.patch(t, '/rest/beer/Heineken', '', function (data, res) {
 			t.equal(res.statusCode, 400, 'HTTP status 400 (Bad Request)');
@@ -359,7 +462,33 @@ test('Methods', function (t) {
 		http.patch(t, '/rest/beer/Heineken', patch, function (data, res) {
 			t.equal(res.statusCode, 204, 'HTTP status 204 (No Content)');
 			heineken.rating = patch.rating;
-			t.deepEqual(collection.get('Heineken'), heineken, 'Heineken with new ranking in collection');
+			t.deepEqual(collection.get('heineken'), heineken, 'Heineken with new ranking in collection');
+			t.end();
+		});
+	});
+
+	t.test('PATCH /rest/beer/HEINEKEN, different capitalisation for resource name', function (t) {
+		const patch = {
+			rating: 2.5
+		};
+
+		http.patch(t, '/rest/beer/HEINEKEN', patch, function (data, res) {
+			t.equal(res.statusCode, 204, 'HTTP status 204 (No Content)');
+			heineken.rating = patch.rating;
+			t.deepEqual(collection.get('heineken'), heineken, 'Heineken with new ranking in collection');
+			t.end();
+		});
+	});
+
+	t.test('PATCH /rest/BEER/Heineken, different capitalisation for collection name', function (t) {
+		const patch = {
+			rating: 2.6
+		};
+
+		http.patch(t, '/rest/beer/Heineken', patch, function (data, res) {
+			t.equal(res.statusCode, 204, 'HTTP status 204 (No Content)');
+			heineken.rating = patch.rating;
+			t.deepEqual(collection.get('heineken'), heineken, 'Heineken with new ranking in collection');
 			t.end();
 		});
 	});
@@ -372,8 +501,24 @@ test('Methods', function (t) {
 		});
 	});
 
+	t.test('GET /rest/BEER returns beer collection despite different capitalisation for collection name', function (t) {
+		http.get(t, '/rest/BEER', function (data, res) {
+			t.equal(res.statusCode, 200, 'HTTP status 200 (OK)');
+			t.deepEqual(data, allButDeMolen, 'All beers but De Molen returned');
+			t.end();
+		});
+	});
+
 	t.test('GET /rest/beer/ (trailing slash)', function (t) {
 		http.get(t, '/rest/beer/', function (data, res) {
+			t.equal(res.statusCode, 200, 'HTTP status 200 (OK)');
+			t.deepEqual(data, allButDeMolen, 'All beers but De Molen returned');
+			t.end();
+		});
+	});
+
+	t.test('GET /rest/BEER/ (trailing slash), different capitalisation for collection name', function (t) {
+		http.get(t, '/rest/BEER/', function (data, res) {
 			t.equal(res.statusCode, 200, 'HTTP status 200 (OK)');
 			t.deepEqual(data, allButDeMolen, 'All beers but De Molen returned');
 			t.end();
@@ -395,6 +540,11 @@ test('Methods', function (t) {
 	});
 
 	t.test('PUT /rest/beer', function (t) {
+		// When a given resource in a collection-PUT doesn't already exist, its id property
+		// will be set from the item's key sent in the collection and will overwrite the
+		// received object's existing id property, if present.
+		// The beer this happens to here is DeMolen, where id changes from 'DeMolen' to 'demolen'.
+		demolen.id = 'demolen';
 		http.put(t, '/rest/beer', all, function (data, res) {
 			t.equal(res.statusCode, 204, 'HTTP status 204 (No Content)');
 			t.deepEqual(collection.getMap(), all, 'Replaced entire collection');
@@ -412,7 +562,7 @@ test('Methods', function (t) {
 
 	t.test('GET /rest/beer.txt?name=en (search)', function (t) {
 		http.get(t, '/rest/beer.txt?name=en', function (data, res) {
-			heineken.id = 'Heineken';
+			heineken.id = 'heineken';
 			const expectedData = [demolen, heineken];
 
 			t.equal(res.statusCode, 200, 'HTTP status 200 (OK)');

--- a/test/rights.js
+++ b/test/rights.js
@@ -35,7 +35,7 @@ test('No rights', function (t) {
 		rating: 1
 	};
 
-	const id = 'Heineken';
+	const id = 'heineken';
 
 	t.test('Injecting Heineken into collection through the backdoor', function (t) {
 		const resource = new Beer(id, heineken);


### PR DESCRIPTION
Collection ID case insensitivity appears straightforward, requiring that the regular expression in setupRoutes.js have case insensitivity enabled.

However, resource ID case insensitivity requires a little opinionation as to how IDs are stored internally. A possible solution, proposed here, is to opt to store them lowercase, which requires a little adjustment of IDs in the test objects.

New method tests have been added to confirm case insensitivity of collections alone, resources within collections, and collections when resources are being accessed within.
